### PR TITLE
Bug/tests paths

### DIFF
--- a/tests/test_DataPreparation.py
+++ b/tests/test_DataPreparation.py
@@ -18,37 +18,41 @@ from syn_net.utils.data_utils import SyntheticTreeSet, Reaction, ReactionSet
 
 TEST_DIR = Path(__file__).parent
 
+
 class TestDataPrep(unittest.TestCase):
     """
     Tests for the data preparation: (1) reaction data processing, (2) synthetic
     tree prep, (3) featurization, (4) training data preparation for each network.
     """
+
     def test_process_rxn_templates(self):
         """
         Tests the rxn templates processing.
         """
         # the following file contains the three templates at the top of
         # 'SynNet/data/rxn_set_hb.txt'
-        path_to_rxn_templates = f'{TEST_DIR}/data/rxn_set_hb_test.txt'
+        path_to_rxn_templates = f"{TEST_DIR}/data/rxn_set_hb_test.txt"
 
         # load the reference building blocks (100 here)
-        path_to_building_blocks = f'{TEST_DIR}/data/building_blocks_matched.csv.gz'
-        building_blocks = pd.read_csv(path_to_building_blocks, compression='gzip')['SMILES'].tolist()
+        path_to_building_blocks = f"{TEST_DIR}/data/building_blocks_matched.csv.gz"
+        building_blocks = pd.read_csv(path_to_building_blocks, compression="gzip")[
+            "SMILES"
+        ].tolist()
 
         # load the reaction templates
         rxn_templates = []
-        with open(path_to_rxn_templates, 'rt') as rxn_template_file:
+        with open(path_to_rxn_templates, "rt") as rxn_template_file:
             for line in rxn_template_file:
-                rxn = Reaction(line.split('|')[1].strip())
+                rxn = Reaction(line.split("|")[1].strip())
                 rxn.set_available_reactants(building_block_list=building_blocks)
                 rxn_templates.append(rxn)
 
         # save the templates as a ReactionSet
         r = ReactionSet(rxn_templates)
-        r.save(f'{TEST_DIR}/data/rxns_hb.json.gz')
+        r.save(f"{TEST_DIR}/data/rxns_hb.json.gz")
 
         # load the reference reaction templates
-        path_to_ref_rxn_templates = f'{TEST_DIR}/data/ref/rxns_hb.json.gz'
+        path_to_ref_rxn_templates = f"{TEST_DIR}/data/ref/rxns_hb.json.gz"
         r_ref = ReactionSet()
         r_ref.load(path_to_ref_rxn_templates)
 
@@ -66,25 +70,25 @@ class TestDataPrep(unittest.TestCase):
         np.random.seed(6)
 
         # load the `Reactions` (built from 3 reaction templates)
-        path_to_rxns = f'{TEST_DIR}/data/ref/rxns_hb.json.gz'
+        path_to_rxns = f"{TEST_DIR}/data/ref/rxns_hb.json.gz"
         r_ref = ReactionSet()
         r_ref.load(path_to_rxns)
         rxns = r_ref.rxns
 
         # load the reference building blocks (100 here)
-        path_to_building_blocks = f'{TEST_DIR}/data/building_blocks_matched.csv.gz'
-        building_blocks = pd.read_csv(path_to_building_blocks, compression='gzip')['SMILES'].tolist()
+        path_to_building_blocks = f"{TEST_DIR}/data/building_blocks_matched.csv.gz"
+        building_blocks = pd.read_csv(path_to_building_blocks, compression="gzip")[
+            "SMILES"
+        ].tolist()
 
-        num_trials   = 25
-        num_finish   = 0
-        num_error    = 0
+        num_trials = 25
+        num_finish = 0
+        num_error = 0
         num_unfinish = 0
 
         trees = []
         for _ in tqdm(range(num_trials)):
-            tree, action = synthetic_tree_generator(building_blocks,
-                                                    rxns,
-                                                    max_step=5)
+            tree, action = synthetic_tree_generator(building_blocks, rxns, max_step=5)
             if action == 3:
                 trees.append(tree)
                 num_finish += 1
@@ -94,7 +98,7 @@ class TestDataPrep(unittest.TestCase):
                 num_unfinish += 1
 
         synthetic_tree_set = SyntheticTreeSet(sts=trees)
-        synthetic_tree_set.save(f'{TEST_DIR}/data/st_data.json.gz')
+        synthetic_tree_set.save(f"{TEST_DIR}/data/st_data.json.gz")
 
         # check that the number of finished trees generated is == 3, and that
         # the number of unfinished trees generated is == 0
@@ -104,7 +108,7 @@ class TestDataPrep(unittest.TestCase):
         # check here that the synthetic trees were correctly saved by
         # comparing to a provided reference file in 'SynNet/tests/data/ref/'
         sts_ref = SyntheticTreeSet()
-        sts_ref.load(f'{TEST_DIR}/data/ref/st_data.json.gz')
+        sts_ref.load(f"{TEST_DIR}/data/ref/st_data.json.gz")
         for st_idx, st in enumerate(sts_ref.sts):
             st = st.__dict__
             ref_st = sts_ref.sts[st_idx].__dict__
@@ -115,14 +119,14 @@ class TestDataPrep(unittest.TestCase):
         Tests the featurization of the synthetic tree data into step-by-step
         data for training.
         """
-        embedding    = 'fp'
-        radius       = 2
-        nbits        = 4096
-        dataset_type = 'train'
+        embedding = "fp"
+        radius = 2
+        nbits = 4096
+        dataset_type = "train"
 
-        path_st            = f'{TEST_DIR}/data/ref/st_data.json.gz'
-        save_dir           = f'{TEST_DIR}/data/'
-        reference_data_dir = f'{TEST_DIR}/data/ref/'
+        path_st = f"{TEST_DIR}/data/ref/st_data.json.gz"
+        save_dir = f"{TEST_DIR}/data/"
+        reference_data_dir = f"{TEST_DIR}/data/ref/"
 
         st_set = SyntheticTreeSet()
         st_set.load(path_st)
@@ -130,15 +134,14 @@ class TestDataPrep(unittest.TestCase):
         del st_set
 
         states = []
-        steps  = []
+        steps = []
 
         save_idx = 0
         for st in tqdm(data):
             try:
-                state, step = organize(st,
-                                       target_embedding=embedding,
-                                       radius=radius,
-                                       nBits=nbits)
+                state, step = organize(
+                    st, target_embedding=embedding, radius=radius, nBits=nbits
+                )
             except Exception as e:
                 print(e)
                 continue
@@ -150,17 +153,21 @@ class TestDataPrep(unittest.TestCase):
         if len(steps) != 0:
             # save the states and steps
             states = sparse.vstack(states)
-            steps  = sparse.vstack(steps)
+            steps = sparse.vstack(steps)
 
             if not os.path.exists(save_dir):
                 os.makedirs(save_dir)
 
-            sparse.save_npz(f'{save_dir}states_{save_idx}_{dataset_type}.npz', states)
-            sparse.save_npz(f'{save_dir}steps_{save_idx}_{dataset_type}.npz', steps)
+            sparse.save_npz(f"{save_dir}states_{save_idx}_{dataset_type}.npz", states)
+            sparse.save_npz(f"{save_dir}steps_{save_idx}_{dataset_type}.npz", steps)
 
         # load the reference data, which we will compare against
-        states_ref = sparse.load_npz(f'{reference_data_dir}states_{save_idx}_{dataset_type}.npz')
-        steps_ref = sparse.load_npz(f'{reference_data_dir}steps_{save_idx}_{dataset_type}.npz')
+        states_ref = sparse.load_npz(
+            f"{reference_data_dir}states_{save_idx}_{dataset_type}.npz"
+        )
+        steps_ref = sparse.load_npz(
+            f"{reference_data_dir}steps_{save_idx}_{dataset_type}.npz"
+        )
 
         # check here that states and steps were correctly saved (need to convert the
         # sparse arrays to non-sparse arrays for comparison)
@@ -176,11 +183,11 @@ class TestDataPrep(unittest.TestCase):
         one-hot encoded Action, Reactant 1, Reactant 2, and Reaction network
         files. In other words, the preparation of data for each specific network.
         """
-        main_dir = f'{TEST_DIR}/data/'
-        ref_dir = f'{TEST_DIR}/data/ref/'
+        main_dir = f"{TEST_DIR}/data/"
+        ref_dir = f"{TEST_DIR}/data/ref/"
         # copy data from the reference directory to use for this particular test
-        copyfile(f'{ref_dir}states_0_train.npz', f'{main_dir}states_0_train.npz')
-        copyfile(f'{ref_dir}steps_0_train.npz', f'{main_dir}steps_0_train.npz')
+        copyfile(f"{ref_dir}states_0_train.npz", f"{main_dir}states_0_train.npz")
+        copyfile(f"{ref_dir}steps_0_train.npz", f"{main_dir}steps_0_train.npz")
 
         # the lines below will save Action-, Reactant 1-, Reaction-, and Reactant 2-
         # specific files directly to the 'SynNet/tests/data/' directory (e.g.
@@ -194,41 +201,41 @@ class TestDataPrep(unittest.TestCase):
         # 'SynNet/tests/data/ref':
 
         # Action network data
-        X_act = sparse.load_npz(f'{main_dir}X_act_train.npz')
-        y_act = sparse.load_npz(f'{main_dir}y_act_train.npz')
+        X_act = sparse.load_npz(f"{main_dir}X_act_train.npz")
+        y_act = sparse.load_npz(f"{main_dir}y_act_train.npz")
 
-        X_act_ref = sparse.load_npz(f'{ref_dir}X_act_train.npz')
-        y_act_ref = sparse.load_npz(f'{ref_dir}y_act_train.npz')
+        X_act_ref = sparse.load_npz(f"{ref_dir}X_act_train.npz")
+        y_act_ref = sparse.load_npz(f"{ref_dir}y_act_train.npz")
 
         self.assertEqual(X_act.toarray().all(), X_act_ref.toarray().all())
         self.assertEqual(y_act.toarray().all(), y_act_ref.toarray().all())
 
         # Reactant 1 network data
-        X_rt1 = sparse.load_npz(f'{main_dir}X_rt1_train.npz')
-        y_rt1 = sparse.load_npz(f'{main_dir}y_rt1_train.npz')
+        X_rt1 = sparse.load_npz(f"{main_dir}X_rt1_train.npz")
+        y_rt1 = sparse.load_npz(f"{main_dir}y_rt1_train.npz")
 
-        X_rt1_ref = sparse.load_npz(f'{ref_dir}X_rt1_train.npz')
-        y_rt1_ref = sparse.load_npz(f'{ref_dir}y_rt1_train.npz')
+        X_rt1_ref = sparse.load_npz(f"{ref_dir}X_rt1_train.npz")
+        y_rt1_ref = sparse.load_npz(f"{ref_dir}y_rt1_train.npz")
 
         self.assertEqual(X_rt1.toarray().all(), X_rt1_ref.toarray().all())
         self.assertEqual(y_rt1.toarray().all(), y_rt1_ref.toarray().all())
 
         # Reaction network data
-        X_rxn = sparse.load_npz(f'{main_dir}X_rxn_train.npz')
-        y_rxn = sparse.load_npz(f'{main_dir}y_rxn_train.npz')
+        X_rxn = sparse.load_npz(f"{main_dir}X_rxn_train.npz")
+        y_rxn = sparse.load_npz(f"{main_dir}y_rxn_train.npz")
 
-        X_rxn_ref = sparse.load_npz(f'{ref_dir}X_rxn_train.npz')
-        y_rxn_ref = sparse.load_npz(f'{ref_dir}y_rxn_train.npz')
+        X_rxn_ref = sparse.load_npz(f"{ref_dir}X_rxn_train.npz")
+        y_rxn_ref = sparse.load_npz(f"{ref_dir}y_rxn_train.npz")
 
         self.assertEqual(X_rxn.toarray().all(), X_rxn_ref.toarray().all())
         self.assertEqual(y_rxn.toarray().all(), y_rxn_ref.toarray().all())
 
         # Reactant 2 network data
-        X_rt2 = sparse.load_npz(f'{main_dir}X_rt2_train.npz')
-        y_rt2 = sparse.load_npz(f'{main_dir}y_rt2_train.npz')
+        X_rt2 = sparse.load_npz(f"{main_dir}X_rt2_train.npz")
+        y_rt2 = sparse.load_npz(f"{main_dir}y_rt2_train.npz")
 
-        X_rt2_ref = sparse.load_npz(f'{ref_dir}X_rt2_train.npz')
-        y_rt2_ref = sparse.load_npz(f'{ref_dir}y_rt2_train.npz')
+        X_rt2_ref = sparse.load_npz(f"{ref_dir}X_rt2_train.npz")
+        y_rt2_ref = sparse.load_npz(f"{ref_dir}y_rt2_train.npz")
 
         self.assertEqual(X_rt2.toarray().all(), X_rt2_ref.toarray().all())
         self.assertEqual(y_rt2.toarray().all(), y_rt2_ref.toarray().all())
@@ -238,18 +245,20 @@ class TestDataPrep(unittest.TestCase):
         Tests the building block embedding function.
         """
         # define some constants
-        main_dir = f'{TEST_DIR}/data/'
-        ref_dir = f'{TEST_DIR}/data/ref/'
+        main_dir = f"{TEST_DIR}/data/"
+        ref_dir = f"{TEST_DIR}/data/ref/"
 
         # define model to use for molecular embedding
-        model_type = 'gin_supervised_contextpred'
-        device = 'cpu'
-        model = load_pretrained(model_type).to(device) # used to learn embedding
+        model_type = "gin_supervised_contextpred"
+        device = "cpu"
+        model = load_pretrained(model_type).to(device)  # used to learn embedding
         model.eval()
 
         # load the building blocks
-        path_to_building_blocks = f'{TEST_DIR}/data/building_blocks_matched.csv.gz'
-        building_blocks = pd.read_csv(path_to_building_blocks, compression='gzip')['SMILES'].tolist()
+        path_to_building_blocks = f"{TEST_DIR}/data/building_blocks_matched.csv.gz"
+        building_blocks = pd.read_csv(path_to_building_blocks, compression="gzip")[
+            "SMILES"
+        ].tolist()
 
         # compute the building block embeddings
         embeddings = []
@@ -257,9 +266,9 @@ class TestDataPrep(unittest.TestCase):
             embeddings.append(get_mol_embedding(smi, model=model))
 
         embeddings = np.array(embeddings)
-        np.save(f'{main_dir}building_blocks_emb.npy', embeddings)
+        np.save(f"{main_dir}building_blocks_emb.npy", embeddings)
 
         # load the reference embeddings
-        embeddings_ref = np.load(f'{ref_dir}building_blocks_emb.npy')
+        embeddings_ref = np.load(f"{ref_dir}building_blocks_emb.npy")
 
         self.assertEqual(embeddings.all(), embeddings_ref.all())

--- a/tests/test_DataPreparation.py
+++ b/tests/test_DataPreparation.py
@@ -1,17 +1,22 @@
 """
 Unit tests for the data preparation.
 """
+from pathlib import Path
 import unittest
 import os
 from shutil import copyfile
-import pandas as pd
-from syn_net.utils.predict_utils import get_mol_embedding
-from tqdm import tqdm
-from scipy import sparse
+
+from dgllife.model import load_pretrained
 import numpy as np
+import pandas as pd
+from scipy import sparse
+from tqdm import tqdm
+
+from syn_net.utils.predict_utils import get_mol_embedding
 from syn_net.utils.prep_utils import organize, synthetic_tree_generator, prep_data
 from syn_net.utils.data_utils import SyntheticTreeSet, Reaction, ReactionSet
-from dgllife.model import load_pretrained
+
+TEST_DIR = Path(__file__).parent
 
 class TestDataPrep(unittest.TestCase):
     """
@@ -24,10 +29,10 @@ class TestDataPrep(unittest.TestCase):
         """
         # the following file contains the three templates at the top of
         # 'SynNet/data/rxn_set_hb.txt'
-        path_to_rxn_templates = './data/rxn_set_hb_test.txt'
+        path_to_rxn_templates = f'{TEST_DIR}/data/rxn_set_hb_test.txt'
 
         # load the reference building blocks (100 here)
-        path_to_building_blocks = './data/building_blocks_matched.csv.gz'
+        path_to_building_blocks = f'{TEST_DIR}/data/building_blocks_matched.csv.gz'
         building_blocks = pd.read_csv(path_to_building_blocks, compression='gzip')['SMILES'].tolist()
 
         # load the reaction templates
@@ -40,10 +45,10 @@ class TestDataPrep(unittest.TestCase):
 
         # save the templates as a ReactionSet
         r = ReactionSet(rxn_templates)
-        r.save('./data/rxns_hb.json.gz')
+        r.save(f'{TEST_DIR}/data/rxns_hb.json.gz')
 
         # load the reference reaction templates
-        path_to_ref_rxn_templates = './data/ref/rxns_hb.json.gz'
+        path_to_ref_rxn_templates = f'{TEST_DIR}/data/ref/rxns_hb.json.gz'
         r_ref = ReactionSet()
         r_ref.load(path_to_ref_rxn_templates)
 
@@ -61,13 +66,13 @@ class TestDataPrep(unittest.TestCase):
         np.random.seed(6)
 
         # load the `Reactions` (built from 3 reaction templates)
-        path_to_rxns = './data/ref/rxns_hb.json.gz'
+        path_to_rxns = f'{TEST_DIR}/data/ref/rxns_hb.json.gz'
         r_ref = ReactionSet()
         r_ref.load(path_to_rxns)
         rxns = r_ref.rxns
 
         # load the reference building blocks (100 here)
-        path_to_building_blocks = './data/building_blocks_matched.csv.gz'
+        path_to_building_blocks = f'{TEST_DIR}/data/building_blocks_matched.csv.gz'
         building_blocks = pd.read_csv(path_to_building_blocks, compression='gzip')['SMILES'].tolist()
 
         num_trials   = 25
@@ -89,7 +94,7 @@ class TestDataPrep(unittest.TestCase):
                 num_unfinish += 1
 
         synthetic_tree_set = SyntheticTreeSet(sts=trees)
-        synthetic_tree_set.save('./data/st_data.json.gz')
+        synthetic_tree_set.save(f'{TEST_DIR}/data/st_data.json.gz')
 
         # check that the number of finished trees generated is == 3, and that
         # the number of unfinished trees generated is == 0
@@ -99,7 +104,7 @@ class TestDataPrep(unittest.TestCase):
         # check here that the synthetic trees were correctly saved by
         # comparing to a provided reference file in 'SynNet/tests/data/ref/'
         sts_ref = SyntheticTreeSet()
-        sts_ref.load('./data/ref/st_data.json.gz')
+        sts_ref.load(f'{TEST_DIR}/data/ref/st_data.json.gz')
         for st_idx, st in enumerate(sts_ref.sts):
             st = st.__dict__
             ref_st = sts_ref.sts[st_idx].__dict__
@@ -115,9 +120,9 @@ class TestDataPrep(unittest.TestCase):
         nbits        = 4096
         dataset_type = 'train'
 
-        path_st            = './data/ref/st_data.json.gz'
-        save_dir           = './data/'
-        reference_data_dir = './data/ref/'
+        path_st            = f'{TEST_DIR}/data/ref/st_data.json.gz'
+        save_dir           = f'{TEST_DIR}/data/'
+        reference_data_dir = f'{TEST_DIR}/data/ref/'
 
         st_set = SyntheticTreeSet()
         st_set.load(path_st)
@@ -171,8 +176,8 @@ class TestDataPrep(unittest.TestCase):
         one-hot encoded Action, Reactant 1, Reactant 2, and Reaction network
         files. In other words, the preparation of data for each specific network.
         """
-        main_dir = './data/'
-        ref_dir = './data/ref/'
+        main_dir = f'{TEST_DIR}/data/'
+        ref_dir = f'{TEST_DIR}/data/ref/'
         # copy data from the reference directory to use for this particular test
         copyfile(f'{ref_dir}states_0_train.npz', f'{main_dir}states_0_train.npz')
         copyfile(f'{ref_dir}steps_0_train.npz', f'{main_dir}steps_0_train.npz')
@@ -233,8 +238,8 @@ class TestDataPrep(unittest.TestCase):
         Tests the building block embedding function.
         """
         # define some constants
-        main_dir = './data/'
-        ref_dir = './data/ref/'
+        main_dir = f'{TEST_DIR}/data/'
+        ref_dir = f'{TEST_DIR}/data/ref/'
 
         # define model to use for molecular embedding
         model_type = 'gin_supervised_contextpred'
@@ -243,7 +248,7 @@ class TestDataPrep(unittest.TestCase):
         model.eval()
 
         # load the building blocks
-        path_to_building_blocks = './data/building_blocks_matched.csv.gz'
+        path_to_building_blocks = f'{TEST_DIR}/data/building_blocks_matched.csv.gz'
         building_blocks = pd.read_csv(path_to_building_blocks, compression='gzip')['SMILES'].tolist()
 
         # compute the building block embeddings

--- a/tests/test_Predict.py
+++ b/tests/test_Predict.py
@@ -8,17 +8,21 @@ import numpy as np
 import pandas as pd
 
 from syn_net.utils.predict_utils import (
-    synthetic_tree_decoder_multireactant, mol_fp, load_modules_from_checkpoint
+    synthetic_tree_decoder_multireactant,
+    mol_fp,
+    load_modules_from_checkpoint,
 )
 from syn_net.utils.data_utils import SyntheticTreeSet, ReactionSet
 
 
 TEST_DIR = Path(__file__).parent
 
+
 class TestPredict(unittest.TestCase):
     """
     Tests for model predictions using greedy search.
     """
+
     def test_predict(self):
         """
         Tests synthetic tree generation given a molecular embedding. No beam search.
@@ -26,34 +30,36 @@ class TestPredict(unittest.TestCase):
         np.random.seed(seed=137)
 
         # define some constants (here, for the unit test rxn set)
-        ref_dir      = f'{TEST_DIR}/data/ref/'
-        nbits        = 4096
-        out_dim      = 300
-        featurize    = 'fp'
-        rxn_template = 'unittest'
-        ncpu         = 2
+        ref_dir = f"{TEST_DIR}/data/ref/"
+        nbits = 4096
+        out_dim = 300
+        featurize = "fp"
+        rxn_template = "unittest"
+        ncpu = 2
 
         ### load the purchasable building block embeddings
-        bb_emb = np.load(f'{ref_dir}building_blocks_emb.npy')
+        bb_emb = np.load(f"{ref_dir}building_blocks_emb.npy")
 
         # define path to the reaction templates and purchasable building blocks
-        path_to_reaction_file   = f'{ref_dir}rxns_hb.json.gz'
-        path_to_building_blocks = f'{TEST_DIR}/data/building_blocks_matched.csv.gz'
+        path_to_reaction_file = f"{ref_dir}rxns_hb.json.gz"
+        path_to_building_blocks = f"{TEST_DIR}/data/building_blocks_matched.csv.gz"
 
         # define paths to pretrained modules
-        path_to_act = f'{ref_dir}act.ckpt'
-        path_to_rt1 = f'{ref_dir}rt1.ckpt'
-        path_to_rxn = f'{ref_dir}rxn.ckpt'
-        path_to_rt2 = f'{ref_dir}rt2.ckpt'
+        path_to_act = f"{ref_dir}act.ckpt"
+        path_to_rt1 = f"{ref_dir}rt1.ckpt"
+        path_to_rxn = f"{ref_dir}rxn.ckpt"
+        path_to_rt2 = f"{ref_dir}rt2.ckpt"
 
         # load the purchasable building block SMILES to a dictionary
-        building_blocks = pd.read_csv(path_to_building_blocks, compression='gzip')['SMILES'].tolist()
-        bb_dict         = {building_blocks[i]: i for i in range(len(building_blocks))}
+        building_blocks = pd.read_csv(path_to_building_blocks, compression="gzip")[
+            "SMILES"
+        ].tolist()
+        bb_dict = {building_blocks[i]: i for i in range(len(building_blocks))}
 
         # load the reaction templates as a ReactionSet object
         rxn_set = ReactionSet()
         rxn_set.load(path_to_reaction_file)
-        rxns    = rxn_set.rxns
+        rxns = rxn_set.rxns
 
         # load the pre-trained modules
         act_net, rt1_net, rxn_net, rt2_net = load_modules_from_checkpoint(
@@ -69,7 +75,7 @@ class TestPredict(unittest.TestCase):
         )
 
         # load the query molecules (i.e. molecules to decode)
-        path_to_data = f'{ref_dir}st_data.json.gz'
+        path_to_data = f"{ref_dir}st_data.json.gz"
         sts = SyntheticTreeSet()
         sts.load(path_to_data)
         smis_query = [st.root.smiles for st in sts.sts]
@@ -77,7 +83,7 @@ class TestPredict(unittest.TestCase):
         # start to decode the query molecules (no multiprocessing for the unit tests here)
         smis_decoded = []
         similarities = []
-        trees        = []
+        trees = []
         for smi in smis_query:
             emb = mol_fp(smi)
             smi, similarity, tree, action = synthetic_tree_decoder_multireactant(
@@ -94,17 +100,18 @@ class TestPredict(unittest.TestCase):
                 rxn_template=rxn_template,
                 n_bits=nbits,
                 beam_width=1,
-                max_step=15)
+                max_step=15,
+            )
 
             smis_decoded.append(smi)
             similarities.append(similarity)
             trees.append(tree)
 
         # check the results and compare to the reference values
-        recovery_rate      = np.sum(np.array(similarities) == 1.0) / len(similarities)
+        recovery_rate = np.sum(np.array(similarities) == 1.0) / len(similarities)
         average_similarity = np.mean(np.array(similarities))
 
-        recovery_rate_ref      = 0.0
+        recovery_rate_ref = 0.0
         average_similarity_ref = 0.395045045045045
 
         self.assertEqual(recovery_rate, recovery_rate_ref)

--- a/tests/test_Predict.py
+++ b/tests/test_Predict.py
@@ -1,12 +1,19 @@
 """
 Unit tests for the model predictions.
 """
+from pathlib import Path
 import unittest
+
 import numpy as np
 import pandas as pd
-from syn_net.utils.predict_utils import synthetic_tree_decoder_multireactant, mol_fp, load_modules_from_checkpoint
+
+from syn_net.utils.predict_utils import (
+    synthetic_tree_decoder_multireactant, mol_fp, load_modules_from_checkpoint
+)
 from syn_net.utils.data_utils import SyntheticTreeSet, ReactionSet
 
+
+TEST_DIR = Path(__file__).parent
 
 class TestPredict(unittest.TestCase):
     """
@@ -19,7 +26,7 @@ class TestPredict(unittest.TestCase):
         np.random.seed(seed=137)
 
         # define some constants (here, for the unit test rxn set)
-        ref_dir      = f'./data/ref/'
+        ref_dir      = f'{TEST_DIR}/data/ref/'
         nbits        = 4096
         out_dim      = 300
         featurize    = 'fp'
@@ -31,7 +38,7 @@ class TestPredict(unittest.TestCase):
 
         # define path to the reaction templates and purchasable building blocks
         path_to_reaction_file   = f'{ref_dir}rxns_hb.json.gz'
-        path_to_building_blocks = './data/building_blocks_matched.csv.gz'
+        path_to_building_blocks = f'{TEST_DIR}/data/building_blocks_matched.csv.gz'
 
         # define paths to pretrained modules
         path_to_act = f'{ref_dir}act.ckpt'

--- a/tests/test_Training.py
+++ b/tests/test_Training.py
@@ -11,81 +11,92 @@ from scipy import sparse
 import torch
 
 from syn_net.models.mlp import MLP, load_array
-from syn_net.utils.predict_utils import one_hot_encoder
 
 
 TEST_DIR = Path(__file__).parent
+
 
 class TestTraining(unittest.TestCase):
     """
     Tests for model training: (1) action network, (2) reactant 1 network, (3)
     reaction network, (4) reactant 2 network.
     """
+
     def test_action_network(self):
         """
         Tests the Action Network.
         """
-        embedding         = 'fp'
-        radius            = 2
-        nbits             = 4096
-        batch_size        = 10
-        epochs            = 2
-        ncpu              = 2
-        validation_option = 'accuracy'
-        ref_dir           = f'{TEST_DIR}/data/ref/'
+        embedding = "fp"
+        radius = 2
+        nbits = 4096
+        batch_size = 10
+        epochs = 2
+        ncpu = 2
+        validation_option = "accuracy"
+        ref_dir = f"{TEST_DIR}/data/ref/"
 
-        X = sparse.load_npz(ref_dir + 'X_act_train.npz')
-        y = sparse.load_npz(ref_dir + 'y_act_train.npz')
+        X = sparse.load_npz(ref_dir + "X_act_train.npz")
+        y = sparse.load_npz(ref_dir + "y_act_train.npz")
         X = torch.Tensor(X.A)
-        y = torch.LongTensor(y.A.reshape(-1, ))
+        y = torch.LongTensor(
+            y.A.reshape(
+                -1,
+            )
+        )
         train_data_iter = load_array((X, y), batch_size, ncpu=ncpu, is_train=True)
 
         # use the train data for validation too (just for the unit tests)
         valid_data_iter = load_array((X, y), batch_size, ncpu=ncpu, is_train=False)
 
         pl.seed_everything(0)
-        mlp = MLP(input_dim=int(3 * nbits),
-                  output_dim=4,
-                  hidden_dim=100,
-                  num_layers=3,
-                  dropout=0.5,
-                  num_dropout_layers=1,
-                  task='classification',
-                  loss='cross_entropy',
-                  valid_loss=validation_option,
-                  optimizer='adam',
-                  learning_rate=1e-4,
-                  val_freq=10,
-                  ncpu=ncpu)
+        mlp = MLP(
+            input_dim=int(3 * nbits),
+            output_dim=4,
+            hidden_dim=100,
+            num_layers=3,
+            dropout=0.5,
+            num_dropout_layers=1,
+            task="classification",
+            loss="cross_entropy",
+            valid_loss=validation_option,
+            optimizer="adam",
+            learning_rate=1e-4,
+            val_freq=10,
+            ncpu=ncpu,
+        )
 
-        tb_logger = pl_loggers.TensorBoardLogger(f'act_{embedding}_{radius}_{nbits}_logs/')
-        trainer   = pl.Trainer(max_epochs=epochs, progress_bar_refresh_rate=20, logger=tb_logger)
+        tb_logger = pl_loggers.TensorBoardLogger(
+            f"act_{embedding}_{radius}_{nbits}_logs/"
+        )
+        trainer = pl.Trainer(
+            max_epochs=epochs, progress_bar_refresh_rate=20, logger=tb_logger
+        )
         trainer.fit(mlp, train_data_iter, valid_data_iter)
 
-        train_loss     = float(trainer.callback_metrics["train_loss"])
+        train_loss = float(trainer.callback_metrics["train_loss"])
         train_loss_ref = 1.4203987121582031
 
-        shutil.rmtree(f'act_{embedding}_{radius}_{nbits}_logs/')
+        shutil.rmtree(f"act_{embedding}_{radius}_{nbits}_logs/")
         self.assertEqual(train_loss, train_loss_ref)
 
     def test_reactant1_network(self):
         """
         Tests the Reactant 1 Network.
         """
-        embedding         = 'fp'
-        radius            = 2
-        nbits             = 4096
-        out_dim           = 300
-        batch_size        = 10
-        epochs            = 2
-        ncpu              = 2
-        validation_option = 'nn_accuracy'
-        ref_dir           = f'{TEST_DIR}/data/ref/'
+        embedding = "fp"
+        radius = 2
+        nbits = 4096
+        out_dim = 300
+        batch_size = 10
+        epochs = 2
+        ncpu = 2
+        validation_option = "nn_accuracy"
+        ref_dir = f"{TEST_DIR}/data/ref/"
 
         # load the reaction data
-        X = sparse.load_npz(ref_dir + 'X_rt1_train.npz')
+        X = sparse.load_npz(ref_dir + "X_rt1_train.npz")
         X = torch.Tensor(X.A)
-        y = sparse.load_npz(ref_dir + 'y_rt1_train.npz')
+        y = sparse.load_npz(ref_dir + "y_rt1_train.npz")
         y = torch.Tensor(y.A)
         train_data_iter = load_array((X, y), batch_size, ncpu=ncpu, is_train=True)
 
@@ -93,95 +104,111 @@ class TestTraining(unittest.TestCase):
         valid_data_iter = load_array((X, y), batch_size, ncpu=ncpu, is_train=False)
 
         pl.seed_everything(0)
-        mlp = MLP(input_dim=int(3 * nbits),
-                  output_dim=out_dim,
-                  hidden_dim=100,
-                  num_layers=3,
-                  dropout=0.5,
-                  num_dropout_layers=1,
-                  task='regression',
-                  loss='mse',
-                  valid_loss=validation_option,
-                  optimizer='adam',
-                  learning_rate=1e-4,
-                  val_freq=10,
-                  ncpu=ncpu)
+        mlp = MLP(
+            input_dim=int(3 * nbits),
+            output_dim=out_dim,
+            hidden_dim=100,
+            num_layers=3,
+            dropout=0.5,
+            num_dropout_layers=1,
+            task="regression",
+            loss="mse",
+            valid_loss=validation_option,
+            optimizer="adam",
+            learning_rate=1e-4,
+            val_freq=10,
+            ncpu=ncpu,
+        )
 
-        tb_logger = pl_loggers.TensorBoardLogger(f'rt1_{embedding}_{radius}_{nbits}_logs/')
-        trainer   = pl.Trainer(max_epochs=epochs, progress_bar_refresh_rate=20, logger=tb_logger)
+        tb_logger = pl_loggers.TensorBoardLogger(
+            f"rt1_{embedding}_{radius}_{nbits}_logs/"
+        )
+        trainer = pl.Trainer(
+            max_epochs=epochs, progress_bar_refresh_rate=20, logger=tb_logger
+        )
         trainer.fit(mlp, train_data_iter, valid_data_iter)
 
-        train_loss     = float(trainer.callback_metrics["train_loss"])
+        train_loss = float(trainer.callback_metrics["train_loss"])
         train_loss_ref = 0.35571354627609253
 
-        shutil.rmtree(f'rt1_{embedding}_{radius}_{nbits}_logs/')
+        shutil.rmtree(f"rt1_{embedding}_{radius}_{nbits}_logs/")
         self.assertEqual(train_loss, train_loss_ref)
 
     def test_reaction_network(self):
         """
         Tests the Reaction Network.
         """
-        embedding         = 'fp'
-        radius            = 2
-        nbits             = 4096
-        batch_size        = 10
-        epochs            = 2
-        ncpu              = 2
-        n_templates       = 3  # num templates in 'data/rxn_set_hb_test.txt'
-        validation_option = 'accuracy'
-        ref_dir           = f'{TEST_DIR}/data/ref/'
+        embedding = "fp"
+        radius = 2
+        nbits = 4096
+        batch_size = 10
+        epochs = 2
+        ncpu = 2
+        n_templates = 3  # num templates in 'data/rxn_set_hb_test.txt'
+        validation_option = "accuracy"
+        ref_dir = f"{TEST_DIR}/data/ref/"
 
-        X = sparse.load_npz(ref_dir + 'X_rxn_train.npz')
-        y = sparse.load_npz(ref_dir + 'y_rxn_train.npz')
+        X = sparse.load_npz(ref_dir + "X_rxn_train.npz")
+        y = sparse.load_npz(ref_dir + "y_rxn_train.npz")
         X = torch.Tensor(X.A)
-        y = torch.LongTensor(y.A.reshape(-1, ))
+        y = torch.LongTensor(
+            y.A.reshape(
+                -1,
+            )
+        )
         train_data_iter = load_array((X, y), batch_size, ncpu=ncpu, is_train=True)
 
         # use the train data for validation too (just for the unit tests)
         valid_data_iter = load_array((X, y), batch_size, ncpu=ncpu, is_train=False)
 
         pl.seed_everything(0)
-        mlp = MLP(input_dim=int(4 * nbits),
-                  output_dim=n_templates,
-                  hidden_dim=100,
-                  num_layers=5,
-                  dropout=0.5,
-                  num_dropout_layers=1,
-                  task='classification',
-                  loss='cross_entropy',
-                  valid_loss=validation_option,
-                  optimizer='adam',
-                  learning_rate=1e-4,
-                  val_freq=10,
-                  ncpu=ncpu)
+        mlp = MLP(
+            input_dim=int(4 * nbits),
+            output_dim=n_templates,
+            hidden_dim=100,
+            num_layers=5,
+            dropout=0.5,
+            num_dropout_layers=1,
+            task="classification",
+            loss="cross_entropy",
+            valid_loss=validation_option,
+            optimizer="adam",
+            learning_rate=1e-4,
+            val_freq=10,
+            ncpu=ncpu,
+        )
 
-        tb_logger = pl_loggers.TensorBoardLogger(f'rxn_{embedding}_{radius}_{nbits}_logs/')
-        trainer   = pl.Trainer(max_epochs=epochs, progress_bar_refresh_rate=20, logger=tb_logger)
+        tb_logger = pl_loggers.TensorBoardLogger(
+            f"rxn_{embedding}_{radius}_{nbits}_logs/"
+        )
+        trainer = pl.Trainer(
+            max_epochs=epochs, progress_bar_refresh_rate=20, logger=tb_logger
+        )
         trainer.fit(mlp, train_data_iter, valid_data_iter)
 
-        train_loss     = float(trainer.callback_metrics["train_loss"])
+        train_loss = float(trainer.callback_metrics["train_loss"])
         train_loss_ref = 1.1214743852615356
 
-        shutil.rmtree(f'rxn_{embedding}_{radius}_{nbits}_logs/')
+        shutil.rmtree(f"rxn_{embedding}_{radius}_{nbits}_logs/")
         self.assertEqual(train_loss, train_loss_ref)
 
     def test_reactant2_network(self):
         """
         Tests the Reactant 2 Network.
         """
-        embedding         = 'fp'
-        radius            = 2
-        nbits             = 4096
-        out_dim           = 300
-        batch_size        = 10
-        epochs            = 2
-        ncpu              = 2
-        n_templates       = 3  # num templates in 'data/rxn_set_hb_test.txt'
-        validation_option = 'nn_accuracy'
-        ref_dir           = f'{TEST_DIR}/data/ref/'
+        embedding = "fp"
+        radius = 2
+        nbits = 4096
+        out_dim = 300
+        batch_size = 10
+        epochs = 2
+        ncpu = 2
+        n_templates = 3  # num templates in 'data/rxn_set_hb_test.txt'
+        validation_option = "nn_accuracy"
+        ref_dir = f"{TEST_DIR}/data/ref/"
 
-        X = sparse.load_npz(ref_dir + 'X_rt2_train.npz')
-        y = sparse.load_npz(ref_dir + 'y_rt2_train.npz')
+        X = sparse.load_npz(ref_dir + "X_rt2_train.npz")
+        y = sparse.load_npz(ref_dir + "y_rt2_train.npz")
         X = torch.Tensor(X.A)
         y = torch.Tensor(y.A)
         train_data_iter = load_array((X, y), batch_size, ncpu=ncpu, is_train=True)
@@ -190,26 +217,32 @@ class TestTraining(unittest.TestCase):
         valid_data_iter = load_array((X, y), batch_size, ncpu=ncpu, is_train=False)
 
         pl.seed_everything(0)
-        mlp = MLP(input_dim=int(4 * nbits + n_templates),
-                  output_dim=out_dim,
-                  hidden_dim=100,
-                  num_layers=3,
-                  dropout=0.5,
-                  num_dropout_layers=1,
-                  task='regression',
-                  loss='mse',
-                  valid_loss=validation_option,
-                  optimizer='adam',
-                  learning_rate=1e-4,
-                  val_freq=10,
-                  ncpu=ncpu)
+        mlp = MLP(
+            input_dim=int(4 * nbits + n_templates),
+            output_dim=out_dim,
+            hidden_dim=100,
+            num_layers=3,
+            dropout=0.5,
+            num_dropout_layers=1,
+            task="regression",
+            loss="mse",
+            valid_loss=validation_option,
+            optimizer="adam",
+            learning_rate=1e-4,
+            val_freq=10,
+            ncpu=ncpu,
+        )
 
-        tb_logger = pl_loggers.TensorBoardLogger(f'rt2_{embedding}_{radius}_{nbits}_logs/')
-        trainer   = pl.Trainer(max_epochs=epochs, progress_bar_refresh_rate=20, logger=tb_logger)
+        tb_logger = pl_loggers.TensorBoardLogger(
+            f"rt2_{embedding}_{radius}_{nbits}_logs/"
+        )
+        trainer = pl.Trainer(
+            max_epochs=epochs, progress_bar_refresh_rate=20, logger=tb_logger
+        )
         trainer.fit(mlp, train_data_iter, valid_data_iter)
 
-        train_loss     = float(trainer.callback_metrics["train_loss"])
+        train_loss = float(trainer.callback_metrics["train_loss"])
         train_loss_ref = 0.41246509552001953
 
-        shutil.rmtree(f'rt2_{embedding}_{radius}_{nbits}_logs/')
+        shutil.rmtree(f"rt2_{embedding}_{radius}_{nbits}_logs/")
         self.assertEqual(train_loss, train_loss_ref)

--- a/tests/test_Training.py
+++ b/tests/test_Training.py
@@ -1,15 +1,20 @@
 """
 Unit tests for model training.
 """
+from pathlib import Path
 import unittest
 import shutil
-import torch
+
 import pytorch_lightning as pl
 from pytorch_lightning import loggers as pl_loggers
+from scipy import sparse
+import torch
+
 from syn_net.models.mlp import MLP, load_array
 from syn_net.utils.predict_utils import one_hot_encoder
-from scipy import sparse
 
+
+TEST_DIR = Path(__file__).parent
 
 class TestTraining(unittest.TestCase):
     """
@@ -27,7 +32,7 @@ class TestTraining(unittest.TestCase):
         epochs            = 2
         ncpu              = 2
         validation_option = 'accuracy'
-        ref_dir           = f'./data/ref/'
+        ref_dir           = f'{TEST_DIR}/data/ref/'
 
         X = sparse.load_npz(ref_dir + 'X_act_train.npz')
         y = sparse.load_npz(ref_dir + 'y_act_train.npz')
@@ -75,7 +80,7 @@ class TestTraining(unittest.TestCase):
         epochs            = 2
         ncpu              = 2
         validation_option = 'nn_accuracy'
-        ref_dir           = f'./data/ref/'
+        ref_dir           = f'{TEST_DIR}/data/ref/'
 
         # load the reaction data
         X = sparse.load_npz(ref_dir + 'X_rt1_train.npz')
@@ -124,7 +129,7 @@ class TestTraining(unittest.TestCase):
         ncpu              = 2
         n_templates       = 3  # num templates in 'data/rxn_set_hb_test.txt'
         validation_option = 'accuracy'
-        ref_dir           = f'./data/ref/'
+        ref_dir           = f'{TEST_DIR}/data/ref/'
 
         X = sparse.load_npz(ref_dir + 'X_rxn_train.npz')
         y = sparse.load_npz(ref_dir + 'y_rxn_train.npz')
@@ -173,7 +178,7 @@ class TestTraining(unittest.TestCase):
         ncpu              = 2
         n_templates       = 3  # num templates in 'data/rxn_set_hb_test.txt'
         validation_option = 'nn_accuracy'
-        ref_dir           = f'./data/ref/'
+        ref_dir           = f'{TEST_DIR}/data/ref/'
 
         X = sparse.load_npz(ref_dir + 'X_rt2_train.npz')
         y = sparse.load_npz(ref_dir + 'y_rt2_train.npz')


### PR DESCRIPTION
## Description
this PR fixes pathing issues in the test suite and formats all the tests with `black -l 100`

## Expected behavior
`pytest path/to/syn_net/tests` should work. Instead, it fails every single test when run anywhere *except* `tests/`. I.e., you would need to run
```
$ cd path/to/syn_net/tests
$ pytest
```
## New behavior
```
$ pytest path/to/syn_net/tests
```
now works